### PR TITLE
add shown_times; add report with stats; retain last 500 old messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from spacenews import pull_from_spacenews
 from supercluster import pull_from_supercluster
 from vestaboard import push_to_vestaboard
 
-from utils import get_db, save_db, get_time_remaining
+from utils import get_db, save_db, get_time_remaining, generate_report
 
 # Set up logging
 logging = Logger.setup_logger(__name__)
@@ -23,11 +23,11 @@ YESTERDAY_DATE = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
 MESSAGE_CHANGE_FREQUENCY = 7
 
 SOURCES = {
-    "breaking_defense": pull_from_breaking_defense,
-    "aidy": pull_from_aidy,
     "supercluster": pull_from_supercluster,
     "spacenews": pull_from_spacenews,
-    "nyt": pull_from_nyt
+    "nyt": pull_from_nyt,
+    "aidy": pull_from_aidy,
+    "breaking_defense": pull_from_breaking_defense,
 }
 
 
@@ -93,6 +93,7 @@ def execute(db):
 def main():
     db = get_db()
     execute(db)    
+    generate_report(db)
     db = save_db(db)
 
 if __name__ == '__main__':

--- a/report.md
+++ b/report.md
@@ -1,0 +1,11 @@
+# Source Frequency
+
+| Source | Fetched (Last 1 Day) | Fetched (Last 2 Days) | Shown (Last 1 Day) | Shown (Last 2 Days) |
+|--------|------------------|------------------|----------------|----------------|
+| spacenews | 9 | 14 | 0 | 0 |
+| breaking_defense | 2 | 2 | 0 | 0 |
+| aidy | 2 | 2 | 0 | 0 |
+| supercluster | 1 | 1 | 0 | 0 |
+
+# Shown Order
+

--- a/vestaboard.py
+++ b/vestaboard.py
@@ -2,7 +2,7 @@ import os
 import json
 import logging
 import requests
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Set up logging
 logging.basicConfig(
@@ -193,6 +193,12 @@ def push_to_vestaboard(item):
         logging.info(f"Message pushed to Vestaboard successfully: {vestaboard_response.text}")
 
         item["shown"] = True
+
+        current_datetime = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+        if "shown_at" in item:
+            item["shown_at"].append(current_datetime)
+        else:
+            item["shown_at"] = [current_datetime]
 
         update_source_link(item.get("source_link", "Sorry no more details about this item"))
 


### PR DESCRIPTION
- Add shown_at for each message - tracks the timestamps at which that message was shown
- Generate report that gives an easy view into the numbers related to items fetched, shown per source and the order in which items were shown
- increase the count of old messages kept to 500